### PR TITLE
Bug fix: Ensures timestamp won't be converted to scientific notation

### DIFF
--- a/lib/InfluxDB/LineProtocol.pm
+++ b/lib/InfluxDB/LineProtocol.pm
@@ -53,8 +53,8 @@ sub data2line {
         }
     }
     else {
-        $timestamp = join( '', gettimeofday() ) * 1000;
-        $timestamp *= 10 if length($timestamp) < 19;
+        $timestamp = join( '', gettimeofday(), '000' );
+        $timestamp .= '0' if length($timestamp) < 19;
     }
 
     # If values is not a hashref, convert it into one


### PR DESCRIPTION
- On some systems the creation of the timestamp may result in it being
  written in scientific notation. This patch treats it as a string
  whenever it is touched.
