### PR TITLE
Fixes padding bug in the creation of nanosecond timestamps

### DIFF
--- a/lib/InfluxDB/LineProtocol.pm
+++ b/lib/InfluxDB/LineProtocol.pm
@@ -53,8 +53,10 @@ sub data2line {
         }
     }
     else {
-        $timestamp = join( '', gettimeofday(), '000' );
-        $timestamp .= '0' if length($timestamp) < 19;
+        # Get time of day returns (seconds, microseconds)
+        # $timestamp needs to be nanoseconds
+        # it must also be a string to avoid conversion to sci notations
+        $timestamp = sprintf "%s%06d000", gettimeofday();
     }
 
     # If values is not a hashref, convert it into one


### PR DESCRIPTION
It occurred to me that joining the results of gettimeofday was not really
generating a timestamp in microseconds. The second return value can be
anywhere from 0 to 99999. So join('', gettimeofday, '000') could range
from 14-19 digits for current dates/times (ie, representing the current time in anywhere from milliseconds to nanoseconds):

As proof:

```
$ perl -MTime::HiRes=gettimeofday -E'for(1..1_000_000){ my $x =
join("",gettimeofday,"000"); my $l = length $x; $count++; $f{$l}++;
} say "$_ => $f{$_}" for sort keys %f;'

14 => 7
15 => 78
16 => 790
17 => 7878
19 => 915790
```

This solution (sprintf) was benchmarked vs hand padding the microseconds. It
was marginally slower (3-7%), but still preferred due to clarity.
