### PR TITLE
Fix spelling mistakes

### DIFF
--- a/lib/InfluxDB/LineProtocol.pm
+++ b/lib/InfluxDB/LineProtocol.pm
@@ -96,7 +96,7 @@ sub data2line {
     my $key = $measurement;
     $key =~ s/([, ])/\\$1/g;
 
-    # $tags has to be a hashref, if it's not, we dont have tags, so it's the timestamp
+    # $tags has to be a hashref, if it's not, we don't have tags, so it's the timestamp
     if ( defined $tags ) {
         if ( ref($tags) eq 'HASH' ) {
             my @tags;
@@ -218,7 +218,7 @@ sub _data2line_0_9_2 {
     my $key = $measurement;
     $key =~ s/([, ])/\\$1/g;
 
-    # $tags has to be a hashref, if it's not, we dont have tags, so it's the timestamp
+    # $tags has to be a hashref, if it's not, we don't have tags, so it's the timestamp
     if ( defined $tags ) {
         if ( ref($tags) eq 'HASH' ) {
             my @tags;
@@ -343,7 +343,7 @@ L<InfluxDB|https://influxdb.com> is a rather new time series database.
 Since version 0.9 they use their
 L<LineProtocol|https://influxdb.com/docs/v0.9/write_protocols/line.html>
 to write time series data into the database. This module allows you to
-generate such a line from a datastructure, handling all the the annoying
+generate such a line from a datastructure, handling all the annoying
 escaping and sorting for you. You can also use it to parse a line
 (maybe you want to add some tags to a line written by another app).
 
@@ -384,7 +384,7 @@ C<Time::HiRes> to get the current timestamp.
 
   my ($metric, $value_hashref, $tags_hashref, $timestamp) = line2data( $line );
 
-C<line2data> parses an InfluxDB line and allways returns 4 values.
+C<line2data> parses an InfluxDB line and always returns 4 values.
 
 C<tags_hashref> is undef if there are no tags!
 


### PR DESCRIPTION
This was detected and warned by lintian and codespell, while preparing Debian packaging.