### PR TITLE
fix POD syntax

### DIFF
--- a/lib/InfluxDB/LineProtocol.pm
+++ b/lib/InfluxDB/LineProtocol.pm
@@ -522,7 +522,7 @@ handling large scientific notation data.
 
 =item *
 
-L< zachary-bull |https://github.com/zachary-bull> for adding code to escape C<=> in tag keys.
+L<zachary-bull|https://github.com/zachary-bull> for adding code to escape C<=> in tag keys.
 
 =back
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
InfluxDB-LineProtocol.
We thought you might be interested in it too.

    Description: fix POD syntax
     % podchecker ./lib/InfluxDB/LineProtocol.pm
     *** ERROR: L<> starts or ends with whitespace at line 535 in file ./lib/InfluxDB/LineProtocol.pm
     ./lib/InfluxDB/LineProtocol.pm has 1 pod syntax error.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-05-08
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libinfluxdb-lineprotocol-perl/raw/master/debian/patches/pod-syntax.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
